### PR TITLE
add db generated timestamps and limit previous games results

### DIFF
--- a/drizzle/0001_daily_elektra.sql
+++ b/drizzle/0001_daily_elektra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "games" ADD COLUMN "time_created" timestamp DEFAULT NOW();

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,63 @@
+{
+  "id": "98a23c69-424c-4607-ace1-bfbd4d61484c",
+  "prevId": "05017277-8bdc-4152-84e4-3a2f4569eb8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board": {
+          "name": "board",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_player": {
+          "name": "current_player",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_state": {
+          "name": "end_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1749071634188,
       "tag": "0000_great_cable",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1749220295975,
+      "tag": "0001_daily_elektra",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,8 +1,10 @@
-import { pgTable, uuid, text, jsonb } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, jsonb, timestamp } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm'
 
 export const games = pgTable('games', {
   id: uuid('id').primaryKey(),
   board: jsonb('board').notNull(),
   currentPlayer: text('current_player').notNull(),
   endState: text('end_state'),
+  timeCreated: timestamp('time_created').default(sql`NOW()`)
 });

--- a/src/game.ts
+++ b/src/game.ts
@@ -8,10 +8,11 @@ export type Game = {
     id: string,
     board: Board,
     currentPlayer: Player,
-    endState?: EndState
+    endState?: EndState,
+    timeCreated: string
 }
 
-export const initialGameState = (): Omit<Game, 'id'> => {
+export const initialGameState = (): Omit<Game, 'id' | 'timeCreated'> => {
     return {
         board: [null, null, null, null, null, null, null, null, null],
         currentPlayer: 'x'


### PR DESCRIPTION
Added time_created timestamp column to database with DEFAULT NOW()
Updated db API getGames() to order by creation time descending and limit to 10 most recent games
Updated Game type to include timeCreated property
Lobby now displays only 10 games